### PR TITLE
feat: KS-7 Dockerfile 작성 및 prod 구성 (docker network 내 mysql dns 사용)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:17-jdk-oracle
+
+WORKDIR /var/app
+
+COPY pom.xml pom.xml
+COPY src src
+COPY .mvn .mvn
+COPY mvnw mvnw
+
+RUN chmod +x mvnw
+
+RUN ./mvnw clean package -DskipTests
+
+CMD java -jar target/kream-0.0.1-SNAPSHOT.jar --spring.active.profiles=prod

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:mysql://mysql:1521/kreamishdb?serverTimezone=UTC
+    username: kreamishwas
+    password: kreamish
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database: mysql
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        #show_sql: true
+        format_sql: true
+    database-platform: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
jdk 이미지로 Dockerfile 작성했습니다.

application-prod 에선 localhost 가 아니라 mysql 로 이름을 지정했습니다.

도커 네트워크 내에서 container name 으로 dns 를 제공해줘서, 통신이 가능합니다.
(도커는 컨테이너가 격리 되어 있어서 localhost 로는 통신이 안됩니다.)